### PR TITLE
Fix youtube extension recommendation hiding

### DIFF
--- a/EXTENSION_README.md
+++ b/EXTENSION_README.md
@@ -1,0 +1,137 @@
+# Productive YouTube Chrome Extension
+
+## 🎯 Overview
+This Chrome extension helps you stay focused while using YouTube by hiding distracting recommendation content from the homepage and other areas of the site.
+
+## 🔧 What Was Fixed
+
+The original extension wasn't working because it likely had issues with:
+
+1. **Incomplete CSS Selectors**: The extension now targets all the current YouTube DOM elements that contain recommendations:
+   - `ytd-rich-grid-renderer` - Main homepage recommendation grid
+   - `ytd-rich-section-renderer` - Recommendation sections
+   - `ytd-rich-shelf-renderer` - Various recommendation shelves
+   - `ytd-reel-shelf-renderer` - YouTube Shorts recommendations
+   - And many more specific selectors
+
+2. **Missing DOM Monitoring**: YouTube is a single-page application that loads content dynamically. The extension now includes:
+   - `MutationObserver` to detect when new content is loaded
+   - Proper handling of YouTube's navigation system
+   - Debounced re-application of hiding rules
+
+3. **CSS Specificity Issues**: Added `!important` declarations and multiple CSS approaches:
+   - Inline style overrides
+   - CSS file rules with high specificity
+   - JavaScript-based hiding as backup
+
+4. **Timing Issues**: The extension now:
+   - Runs at `document_start` for early intervention
+   - Has multiple initialization points (DOMContentLoaded, window load)
+   - Includes delayed execution to catch late-loading content
+
+## ✨ Features
+
+- **Hide Homepage Recommendations**: Removes all video recommendations from YouTube's homepage
+- **Hide Sidebar Recommendations**: Removes suggested videos while watching content
+- **Hide End Screen Suggestions**: Removes video suggestions at the end of videos
+- **Optional Comment Hiding**: Can hide comment sections if desired
+- **User-Friendly Popup**: Easy toggle controls for each feature
+- **Persistent Settings**: Your preferences are saved and synced across devices
+
+## 📥 Installation
+
+1. **Download the extension files**:
+   - `manifest.json`
+   - `content.js`
+   - `styles.css`
+   - `popup.html`
+   - `popup.js`
+
+2. **Load in Chrome**:
+   - Open Chrome and go to `chrome://extensions/`
+   - Enable "Developer mode" (toggle in top right)
+   - Click "Load unpacked"
+   - Select the folder containing the extension files
+
+3. **Activate**:
+   - The extension will automatically start working on YouTube
+   - Click the extension icon to access settings
+
+## 🎮 Usage
+
+### Automatic Operation
+- The extension works automatically when you visit YouTube
+- Recommendations are hidden by default on the homepage and sidebar
+
+### Manual Controls
+- Click the extension icon in your toolbar
+- Use the toggle switches to enable/disable specific features:
+  - **Hide Recommendations**: Homepage video grid
+  - **Hide Sidebar**: Related videos while watching
+  - **Hide End Screens**: Video end suggestions
+  - **Hide Comments**: Comment sections (optional)
+
+### Keyboard Shortcuts (in popup)
+- `1` - Toggle homepage recommendations
+- `2` - Toggle sidebar recommendations
+- `3` - Toggle end screen hiding
+- `4` - Toggle comment hiding
+- `Ctrl/Cmd + R` - Refresh current tab
+
+## 🛠️ Technical Details
+
+### How It Works
+1. **CSS Injection**: Styles are injected to immediately hide known recommendation elements
+2. **DOM Monitoring**: JavaScript monitors for dynamically loaded content
+3. **Multi-layered Approach**: Combines CSS and JavaScript for maximum effectiveness
+4. **Persistent Configuration**: Settings are saved using Chrome's storage API
+
+### Targeted Elements
+The extension targets these specific YouTube elements:
+- Main recommendation grids and shelves
+- Sidebar suggestion containers
+- End screen overlays
+- Shorts recommendation shelves
+- Related video sections
+- Promotional content areas
+
+### Performance
+- Lightweight: Minimal impact on page loading
+- Efficient: Uses CSS for primary hiding with JavaScript backup
+- Optimized: Debounced re-application prevents excessive operations
+
+## 🐛 Troubleshooting
+
+### Extension Not Working?
+1. **Refresh the page**: Click the refresh button in the extension popup
+2. **Check permissions**: Ensure the extension has permission to access YouTube
+3. **Reload extension**: Go to `chrome://extensions/` and reload the extension
+4. **Clear cache**: Clear your browser cache and cookies for YouTube
+
+### Still Seeing Recommendations?
+1. **New YouTube Layout**: YouTube occasionally updates their layout. The extension may need updates for new elements
+2. **Partial Loading**: Some content might load after the extension runs. Try refreshing the page
+3. **Cached Content**: Clear your YouTube cache or try incognito mode
+
+### Settings Not Saving?
+1. **Storage Permission**: Ensure the extension has storage permission
+2. **Sync Issues**: Settings sync across devices but may take a few minutes
+
+## 🔄 Updates
+
+This extension is designed to be easily updateable when YouTube changes their layout. The selector arrays in `content.js` can be updated to target new elements as they appear.
+
+## 📝 License
+
+This extension is provided as-is for productivity purposes. Feel free to modify and improve it for your needs.
+
+## 🤝 Contributing
+
+If you find new YouTube elements that should be hidden or improvements to the code, you can:
+1. Update the `SELECTORS` object in `content.js`
+2. Add new CSS rules in `styles.css`
+3. Test thoroughly on different YouTube pages
+
+---
+
+**Note**: This extension is not affiliated with YouTube or Google. It's a productivity tool designed to help users focus while using the platform.

--- a/content.js
+++ b/content.js
@@ -1,0 +1,234 @@
+// YouTube Recommendation Hider - Content Script
+// This script hides various recommendation elements on YouTube
+
+(function() {
+    'use strict';
+    
+    // Configuration object to store user preferences
+    let config = {
+        hideRecommendations: true,
+        hideSidebar: true,
+        hideEndScreens: true,
+        hideComments: false
+    };
+    
+    // Load configuration from Chrome storage
+    function loadConfig() {
+        if (typeof chrome !== 'undefined' && chrome.storage) {
+            chrome.storage.sync.get(['productiveYouTubeConfig'], function(result) {
+                if (result.productiveYouTubeConfig) {
+                    config = { ...config, ...result.productiveYouTubeConfig };
+                }
+                applyHiding();
+            });
+        } else {
+            applyHiding();
+        }
+    }
+    
+    // Selectors for various YouTube recommendation elements
+    const SELECTORS = {
+        // Homepage recommendations
+        homepage: [
+            'ytd-rich-grid-renderer', // Main recommendation grid
+            'ytd-rich-section-renderer', // Recommendation sections
+            'ytd-rich-shelf-renderer', // Recommendation shelves
+            '#contents.ytd-rich-grid-renderer', // Grid contents
+            'ytd-two-column-browse-results-renderer #primary', // Primary content area
+            '[page-subtype="home"] ytd-rich-grid-renderer',
+            '[page-subtype="home"] #contents',
+            '.ytd-browse[page-subtype="home"]'
+        ],
+        
+        // Sidebar recommendations
+        sidebar: [
+            'ytd-watch-next-secondary-results-renderer', // Watch next sidebar
+            '#secondary.ytd-watch-flexy', // Secondary content
+            'ytd-compact-video-renderer', // Compact video recommendations
+            'ytd-shelf-renderer', // Sidebar shelves
+            '#related' // Related videos
+        ],
+        
+        // End screen recommendations
+        endScreen: [
+            '.ytp-endscreen-content',
+            '.ytp-ce-element',
+            '.ytp-cards-teaser',
+            'ytd-endscreen-element-renderer'
+        ],
+        
+        // Comments (optional)
+        comments: [
+            'ytd-comments',
+            '#comments',
+            'ytd-comment-thread-renderer'
+        ],
+        
+        // Additional elements that might show recommendations
+        additional: [
+            'ytd-reel-shelf-renderer', // Shorts shelf
+            'ytd-video-secondary-info-renderer #meta-contents', // Video meta with recommendations
+            'ytd-merch-shelf-renderer', // Merch shelf
+            'ytd-donation-shelf-renderer' // Donation shelf
+        ]
+    };
+    
+    // Function to hide elements based on selectors
+    function hideElements(selectors) {
+        selectors.forEach(selector => {
+            const elements = document.querySelectorAll(selector);
+            elements.forEach(element => {
+                if (element) {
+                    element.style.display = 'none !important';
+                    element.style.visibility = 'hidden !important';
+                    element.setAttribute('data-productive-youtube-hidden', 'true');
+                }
+            });
+        });
+    }
+    
+    // Function to show elements (for toggling)
+    function showElements(selectors) {
+        selectors.forEach(selector => {
+            const elements = document.querySelectorAll(selector + '[data-productive-youtube-hidden="true"]');
+            elements.forEach(element => {
+                if (element) {
+                    element.style.display = '';
+                    element.style.visibility = '';
+                    element.removeAttribute('data-productive-youtube-hidden');
+                }
+            });
+        });
+    }
+    
+    // Main function to apply hiding based on current config
+    function applyHiding() {
+        // Hide homepage recommendations
+        if (config.hideRecommendations) {
+            hideElements(SELECTORS.homepage);
+            hideElements(SELECTORS.additional);
+        } else {
+            showElements(SELECTORS.homepage);
+            showElements(SELECTORS.additional);
+        }
+        
+        // Hide sidebar recommendations
+        if (config.hideSidebar) {
+            hideElements(SELECTORS.sidebar);
+        } else {
+            showElements(SELECTORS.sidebar);
+        }
+        
+        // Hide end screen recommendations
+        if (config.hideEndScreens) {
+            hideElements(SELECTORS.endScreen);
+        } else {
+            showElements(SELECTORS.endScreen);
+        }
+        
+        // Hide comments if enabled
+        if (config.hideComments) {
+            hideElements(SELECTORS.comments);
+        } else {
+            showElements(SELECTORS.comments);
+        }
+    }
+    
+    // Observer to handle dynamically loaded content
+    const observer = new MutationObserver(function(mutations) {
+        let shouldReapply = false;
+        
+        mutations.forEach(function(mutation) {
+            // Check if new nodes were added
+            if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+                mutation.addedNodes.forEach(function(node) {
+                    if (node.nodeType === Node.ELEMENT_NODE) {
+                        // Check if the added node or its children match our selectors
+                        const allSelectors = [
+                            ...SELECTORS.homepage,
+                            ...SELECTORS.sidebar,
+                            ...SELECTORS.endScreen,
+                            ...SELECTORS.additional
+                        ];
+                        
+                        const matchesSelector = allSelectors.some(selector => {
+                            try {
+                                return node.matches && node.matches(selector) || 
+                                       node.querySelector && node.querySelector(selector);
+                            } catch (e) {
+                                return false;
+                            }
+                        });
+                        
+                        if (matchesSelector) {
+                            shouldReapply = true;
+                        }
+                    }
+                });
+            }
+        });
+        
+        if (shouldReapply) {
+            // Debounce the reapplication to avoid excessive calls
+            clearTimeout(window.productiveYouTubeTimeout);
+            window.productiveYouTubeTimeout = setTimeout(applyHiding, 100);
+        }
+    });
+    
+    // Start observing when DOM is ready
+    function startObserving() {
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: false
+        });
+    }
+    
+    // Initialize the extension
+    function initialize() {
+        console.log('Productive YouTube: Initializing...');
+        
+        // Apply hiding immediately if DOM is ready
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', function() {
+                loadConfig();
+                setTimeout(startObserving, 1000);
+            });
+        } else {
+            loadConfig();
+            setTimeout(startObserving, 1000);
+        }
+        
+        // Also apply on window load to catch any late-loading content
+        window.addEventListener('load', function() {
+            setTimeout(applyHiding, 2000);
+        });
+        
+        // Handle YouTube's single-page app navigation
+        let lastUrl = location.href;
+        new MutationObserver(() => {
+            const url = location.href;
+            if (url !== lastUrl) {
+                lastUrl = url;
+                setTimeout(applyHiding, 1000);
+            }
+        }).observe(document, { subtree: true, childList: true });
+    }
+    
+    // Listen for messages from popup
+    if (typeof chrome !== 'undefined' && chrome.runtime) {
+        chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+            if (request.action === 'updateConfig') {
+                config = { ...config, ...request.config };
+                applyHiding();
+                sendResponse({ success: true });
+            } else if (request.action === 'getConfig') {
+                sendResponse({ config: config });
+            }
+        });
+    }
+    
+    // Start the extension
+    initialize();
+    
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 3,
+  "name": "Productive YouTube",
+  "version": "1.0",
+  "description": "Hide YouTube recommendations to stay focused and productive",
+  "permissions": [
+    "activeTab",
+    "storage"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["*://*.youtube.com/*"],
+      "js": ["content.js"],
+      "css": ["styles.css"],
+      "run_at": "document_start"
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Productive YouTube"
+  },
+  "icons": {
+    "16": "icon16.png",
+    "48": "icon48.png",
+    "128": "icon128.png"
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Productive YouTube</title>
+    <style>
+        body {
+            width: 300px;
+            padding: 20px;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            margin: 0;
+        }
+        
+        .header {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        
+        .header h1 {
+            margin: 0;
+            font-size: 24px;
+            font-weight: 600;
+        }
+        
+        .header p {
+            margin: 5px 0 0 0;
+            opacity: 0.8;
+            font-size: 14px;
+        }
+        
+        .settings {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 16px;
+            backdrop-filter: blur(10px);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+        }
+        
+        .setting-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 12px;
+            padding: 8px 0;
+        }
+        
+        .setting-item:last-child {
+            margin-bottom: 0;
+        }
+        
+        .setting-label {
+            font-size: 14px;
+            font-weight: 500;
+        }
+        
+        .setting-description {
+            font-size: 12px;
+            opacity: 0.7;
+            margin-top: 2px;
+        }
+        
+        .toggle {
+            position: relative;
+            width: 44px;
+            height: 24px;
+            background: rgba(255, 255, 255, 0.3);
+            border-radius: 12px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+        
+        .toggle.active {
+            background: #4CAF50;
+        }
+        
+        .toggle::after {
+            content: '';
+            position: absolute;
+            top: 2px;
+            left: 2px;
+            width: 20px;
+            height: 20px;
+            background: white;
+            border-radius: 50%;
+            transition: all 0.3s ease;
+        }
+        
+        .toggle.active::after {
+            transform: translateX(20px);
+        }
+        
+        .status {
+            text-align: center;
+            margin-top: 16px;
+            padding: 8px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 8px;
+            font-size: 12px;
+            opacity: 0.8;
+        }
+        
+        .refresh-btn {
+            width: 100%;
+            padding: 10px;
+            margin-top: 12px;
+            background: rgba(255, 255, 255, 0.2);
+            color: white;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 500;
+            transition: all 0.3s ease;
+        }
+        
+        .refresh-btn:hover {
+            background: rgba(255, 255, 255, 0.3);
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>🎯 Productive YouTube</h1>
+        <p>Stay focused, avoid distractions</p>
+    </div>
+    
+    <div class="settings">
+        <div class="setting-item">
+            <div>
+                <div class="setting-label">Hide Recommendations</div>
+                <div class="setting-description">Homepage video recommendations</div>
+            </div>
+            <div class="toggle" id="hideRecommendations"></div>
+        </div>
+        
+        <div class="setting-item">
+            <div>
+                <div class="setting-label">Hide Sidebar</div>
+                <div class="setting-description">Related videos while watching</div>
+            </div>
+            <div class="toggle" id="hideSidebar"></div>
+        </div>
+        
+        <div class="setting-item">
+            <div>
+                <div class="setting-label">Hide End Screens</div>
+                <div class="setting-description">Video end screen suggestions</div>
+            </div>
+            <div class="toggle" id="hideEndScreens"></div>
+        </div>
+        
+        <div class="setting-item">
+            <div>
+                <div class="setting-label">Hide Comments</div>
+                <div class="setting-description">Comment sections (optional)</div>
+            </div>
+            <div class="toggle" id="hideComments"></div>
+        </div>
+        
+        <button class="refresh-btn" id="refreshPage">Refresh Current Tab</button>
+        
+        <div class="status" id="status">
+            Extension is active and blocking distractions
+        </div>
+    </div>
+    
+    <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,206 @@
+// Popup script for Productive YouTube extension
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Default configuration
+    const defaultConfig = {
+        hideRecommendations: true,
+        hideSidebar: true,
+        hideEndScreens: true,
+        hideComments: false
+    };
+    
+    let currentConfig = { ...defaultConfig };
+    
+    // DOM elements
+    const toggles = {
+        hideRecommendations: document.getElementById('hideRecommendations'),
+        hideSidebar: document.getElementById('hideSidebar'),
+        hideEndScreens: document.getElementById('hideEndScreens'),
+        hideComments: document.getElementById('hideComments')
+    };
+    
+    const refreshBtn = document.getElementById('refreshPage');
+    const statusDiv = document.getElementById('status');
+    
+    // Load saved configuration
+    function loadConfig() {
+        chrome.storage.sync.get(['productiveYouTubeConfig'], function(result) {
+            if (result.productiveYouTubeConfig) {
+                currentConfig = { ...defaultConfig, ...result.productiveYouTubeConfig };
+            }
+            updateUI();
+        });
+    }
+    
+    // Save configuration
+    function saveConfig() {
+        chrome.storage.sync.set({
+            productiveYouTubeConfig: currentConfig
+        }, function() {
+            console.log('Configuration saved:', currentConfig);
+            updateStatus('Settings saved successfully!');
+            
+            // Send message to content script
+            sendMessageToContentScript();
+        });
+    }
+    
+    // Update UI based on current configuration
+    function updateUI() {
+        Object.keys(toggles).forEach(key => {
+            const toggle = toggles[key];
+            const isActive = currentConfig[key];
+            
+            if (isActive) {
+                toggle.classList.add('active');
+            } else {
+                toggle.classList.remove('active');
+            }
+        });
+        
+        updateStatus();
+    }
+    
+    // Update status message
+    function updateStatus(message = null) {
+        if (message) {
+            statusDiv.textContent = message;
+            setTimeout(() => {
+                updateStatus();
+            }, 2000);
+            return;
+        }
+        
+        const activeFeatures = Object.keys(currentConfig).filter(key => currentConfig[key]);
+        const count = activeFeatures.length;
+        
+        if (count === 0) {
+            statusDiv.textContent = 'All features disabled';
+        } else {
+            statusDiv.textContent = `${count} distraction${count === 1 ? '' : 's'} blocked`;
+        }
+    }
+    
+    // Send message to content script
+    function sendMessageToContentScript() {
+        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            if (tabs[0] && tabs[0].url && tabs[0].url.includes('youtube.com')) {
+                chrome.tabs.sendMessage(tabs[0].id, {
+                    action: 'updateConfig',
+                    config: currentConfig
+                }, function(response) {
+                    if (chrome.runtime.lastError) {
+                        console.log('Could not send message to content script:', chrome.runtime.lastError.message);
+                        updateStatus('Refresh the page to apply changes');
+                    } else if (response && response.success) {
+                        updateStatus('Changes applied successfully!');
+                    }
+                });
+            } else {
+                updateStatus('Navigate to YouTube to use this extension');
+            }
+        });
+    }
+    
+    // Add click listeners to toggles
+    Object.keys(toggles).forEach(key => {
+        const toggle = toggles[key];
+        
+        toggle.addEventListener('click', function() {
+            currentConfig[key] = !currentConfig[key];
+            updateUI();
+            saveConfig();
+        });
+    });
+    
+    // Refresh button functionality
+    refreshBtn.addEventListener('click', function() {
+        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            if (tabs[0]) {
+                chrome.tabs.reload(tabs[0].id);
+                updateStatus('Page refreshed!');
+                
+                // Close popup after refresh
+                setTimeout(() => {
+                    window.close();
+                }, 1000);
+            }
+        });
+    });
+    
+    // Check if we're on a YouTube page
+    function checkYouTubePage() {
+        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            if (tabs[0] && tabs[0].url) {
+                if (tabs[0].url.includes('youtube.com')) {
+                    // Try to get config from content script
+                    chrome.tabs.sendMessage(tabs[0].id, {
+                        action: 'getConfig'
+                    }, function(response) {
+                        if (response && response.config) {
+                            currentConfig = { ...defaultConfig, ...response.config };
+                            updateUI();
+                        }
+                    });
+                } else {
+                    updateStatus('This extension only works on YouTube');
+                }
+            }
+        });
+    }
+    
+    // Initialize popup
+    function initialize() {
+        loadConfig();
+        checkYouTubePage();
+        
+        // Update status periodically
+        setInterval(updateStatus, 5000);
+    }
+    
+    // Start initialization
+    initialize();
+    
+    // Handle keyboard shortcuts
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'r' && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            refreshBtn.click();
+        }
+        
+        // Toggle features with number keys
+        const keyMap = {
+            '1': 'hideRecommendations',
+            '2': 'hideSidebar',
+            '3': 'hideEndScreens',
+            '4': 'hideComments'
+        };
+        
+        if (keyMap[e.key]) {
+            e.preventDefault();
+            toggles[keyMap[e.key]].click();
+        }
+    });
+    
+    // Add tooltips or help text
+    const helpText = {
+        hideRecommendations: 'Removes all video recommendations from YouTube homepage',
+        hideSidebar: 'Hides suggested videos in the sidebar while watching',
+        hideEndScreens: 'Removes end screen video suggestions',
+        hideComments: 'Hides comment sections (may affect engagement)'
+    };
+    
+    // Add hover effects for better UX
+    Object.keys(toggles).forEach(key => {
+        const toggle = toggles[key];
+        const settingItem = toggle.closest('.setting-item');
+        
+        settingItem.addEventListener('mouseenter', function() {
+            toggle.style.transform = 'scale(1.05)';
+        });
+        
+        settingItem.addEventListener('mouseleave', function() {
+            toggle.style.transform = 'scale(1)';
+        });
+    });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,145 @@
+/* Productive YouTube - Styles to hide recommendations */
+
+/* Hide homepage recommendation grid and related elements */
+ytd-rich-grid-renderer,
+ytd-rich-section-renderer,
+ytd-rich-shelf-renderer,
+#contents.ytd-rich-grid-renderer,
+ytd-two-column-browse-results-renderer #primary,
+[page-subtype="home"] ytd-rich-grid-renderer,
+[page-subtype="home"] #contents,
+.ytd-browse[page-subtype="home"] {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+}
+
+/* Hide sidebar recommendations */
+ytd-watch-next-secondary-results-renderer,
+#secondary.ytd-watch-flexy,
+ytd-compact-video-renderer,
+ytd-shelf-renderer,
+#related {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+}
+
+/* Hide end screen recommendations */
+.ytp-endscreen-content,
+.ytp-ce-element,
+.ytp-cards-teaser,
+ytd-endscreen-element-renderer {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+}
+
+/* Hide additional recommendation elements */
+ytd-reel-shelf-renderer,
+ytd-video-secondary-info-renderer #meta-contents,
+ytd-merch-shelf-renderer,
+ytd-donation-shelf-renderer {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+}
+
+/* Hide YouTube Shorts recommendations */
+ytd-rich-shelf-renderer[is-shorts],
+ytd-reel-shelf-renderer,
+.ytd-rich-shelf-renderer[is-shorts] {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+}
+
+/* Hide "Up next" and autoplay recommendations */
+.ytp-upnext,
+.ytp-pause-overlay,
+.ytp-scroll-min,
+.ytp-videowall-still {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+}
+
+/* Hide masthead (top bar) recommendations if any */
+#masthead-ad {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    height: 0 !important;
+}
+
+/* Clean up the layout when recommendations are hidden */
+ytd-two-column-browse-results-renderer {
+    display: flex !important;
+    justify-content: center !important;
+}
+
+/* Center the search bar and make the page cleaner */
+ytd-app[is-watch-page] #columns #primary.ytd-watch-flexy {
+    max-width: 100% !important;
+    padding-right: 0 !important;
+}
+
+/* Hide promotional banners and ads related to recommendations */
+ytd-display-ad-renderer,
+ytd-promoted-sparkles-web-renderer,
+ytd-ad-slot-renderer {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+}
+
+/* Override any inline styles that might show recommendations */
+[data-productive-youtube-hidden="true"] {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    height: 0 !important;
+    max-height: 0 !important;
+    overflow: hidden !important;
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+/* Hide mini-player recommendations */
+.ytp-miniplayer .ytp-upnext,
+.ytp-miniplayer .ytp-scroll-min {
+    display: none !important;
+    visibility: hidden !important;
+}
+
+/* Additional specificity for stubborn elements */
+body ytd-rich-grid-renderer,
+body ytd-rich-section-renderer,
+body ytd-rich-shelf-renderer {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+}
+
+/* Hide comments section if enabled in settings */
+.productive-youtube-hide-comments ytd-comments,
+.productive-youtube-hide-comments #comments,
+.productive-youtube-hide-comments ytd-comment-thread-renderer {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+}


### PR DESCRIPTION
A new Chrome extension was created to hide YouTube recommendations, addressing several common issues.

The core changes involved:
*   **New File Structure**: `manifest.json` defines the extension, `content.js` handles the hiding logic, `styles.css` provides forceful CSS rules, `popup.html` and `popup.js` create a user interface for settings, and `EXTENSION_README.md` provides installation instructions.
*   **Comprehensive DOM Targeting**: `content.js` and `styles.css` now include an extensive set of selectors (e.g., `ytd-rich-grid-renderer`, `ytd-watch-next-secondary-results-renderer`) to target various recommendation elements across the homepage, sidebar, and end screens.
*   **Dynamic Content Handling**: `content.js` implements a `MutationObserver` to detect and hide dynamically loaded content, ensuring recommendations are hidden even after page navigation or lazy loading. Debouncing prevents excessive re-application.
*   **CSS Specificity and Timing**: `styles.css` uses `!important` declarations for strong hiding. The `manifest.json` sets `run_at: "document_start"` for `content.js` and `styles.css` to ensure early intervention, complemented by multiple initialization points in `content.js` to catch late-loading elements.
*   **User Control**: `popup.html` and `popup.js` provide toggles for hiding recommendations, sidebar content, end screens, and comments, with settings persistently saved using `chrome.storage.sync`.